### PR TITLE
Handle headerless Google Sheets

### DIFF
--- a/script_iran_seda_final_STREAM_MERGE_v6_env.py
+++ b/script_iran_seda_final_STREAM_MERGE_v6_env.py
@@ -55,6 +55,19 @@ def read_gsheet(url: str):
         if m:
             bid = m.group(1)
         rows.append({"AudioBook_ID": bid, "URL": u, "Summary": row.get("Summary") or row.get("Book_Summary")})
+    if not rows:
+        reader2 = csv.reader(io.StringIO(content))
+        for row in reader2:
+            if not row:
+                continue
+            u = row[0].strip()
+            if not u or u.lower() == "url":
+                continue
+            bid = None
+            m = re.search(r"[?&]g=(\d+)", u)
+            if m:
+                bid = m.group(1)
+            rows.append({"AudioBook_ID": bid, "URL": u, "Summary": None})
     return pd.DataFrame(rows)
 
 def abs_url(u: str) -> str:

--- a/tests/test_read_gsheet.py
+++ b/tests/test_read_gsheet.py
@@ -1,0 +1,22 @@
+import importlib.util
+import pathlib
+from unittest.mock import patch, MagicMock
+
+script_path = pathlib.Path(__file__).resolve().parents[1] / 'script_iran_seda_final_STREAM_MERGE_v6_env.py'
+spec = importlib.util.spec_from_file_location('script_module', script_path)
+mod = importlib.util.module_from_spec(spec)
+import sys
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+@patch('script_module.requests.get')
+def test_read_gsheet_single_url(mock_get):
+    content = 'http://book.iranseda.ir/DetailsAlbum/?VALID=TRUE&g=674800'
+    resp = MagicMock()
+    resp.content = content.encode('utf-8')
+    resp.raise_for_status = lambda: None
+    mock_get.return_value = resp
+    df = mod.read_gsheet('https://docs.google.com/spreadsheets/d/test/export?format=csv')
+    assert not df.empty
+    assert df.iloc[0]['URL'] == content
+    assert df.iloc[0]['AudioBook_ID'] == '674800'


### PR DESCRIPTION
## Summary
- improve Google Sheet ingestion to handle sheets without URL header rows
- add unit test ensuring a single-URL sheet is parsed correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a9dfcd14988325b50e582b3c553f8c