### PR TITLE
Ensure book descriptions scraped from meta tags

### DIFF
--- a/tests/test_parse_page_description.py
+++ b/tests/test_parse_page_description.py
@@ -1,0 +1,24 @@
+import importlib.util
+import pathlib
+
+# Dynamically load the script module to avoid path issues
+script_path = pathlib.Path(__file__).resolve().parents[1] / 'script_iran_seda_final_STREAM_MERGE_v6_env.py'
+spec = importlib.util.spec_from_file_location('script_module', script_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+parse_page = mod.parse_page
+
+def test_parse_page_uses_meta_description():
+    html = """
+    <html>
+      <head>
+        <meta name='description' content='meta description here'>
+      </head>
+      <body>
+        <h1>عنوانی</h1>
+      </body>
+    </html>
+    """
+    result = parse_page(html, "http://example.com")
+    assert result["Book_Description"] == "meta description here"


### PR DESCRIPTION
## Summary
- Parse IranSeda pages for short descriptions using multiple selectors and meta tags as fallback
- Add regression test confirming `parse_page` reads description from `<meta name="description">`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a9e60689208325aac2d23409f0a1fa