### PR TITLE
Use Book_Detail for feed description and update channel info

### DIFF
--- a/tests/test_csv_to_podcast.py
+++ b/tests/test_csv_to_podcast.py
@@ -56,14 +56,12 @@ def test_build_item_contains_translated_fields(mock_head):
     mock_head.return_value = _mock_response(headers)
     row = {
         "Book_Title": "عنوانی",
-        "Book_Description": "توضیحی",
         "Book_Detail": "جزئیاتی",
         "FullBook_MP3_URL": "http://example.com/a.mp3",
     }
     item = build_item(row, "Wed, 01 Jan 2024 00:00:00 +0000")
     assert "عنوان کتاب: عنوانی" in item
-    assert "توضیحات کتاب: توضیحی" in item
-    assert "جزئیات/متن کامل معرفی: جزئیاتی" in item
+    assert "توضیحات کتاب: جزئیاتی" in item
 
 
 @patch("tools.csv_to_podcast.requests.head")
@@ -88,8 +86,7 @@ def test_long_description_trims_optional_fields(mock_head):
     mod.MAX_DESC_LENGTH = 80
     row = {
         "Book_Title": "T",
-        "Book_Description": "D",
-        "Book_Detail": "DETAIL",
+        "Book_Detail": "DETAILDETAILDETAILDETAILDETAILDETAILDETAIL",
         "Book_Language": "FA",
         "Book_Country": "IR",
         "FullBook_MP3_URL": "http://example.com/a.mp3",

--- a/tests/test_parse_page_description.py
+++ b/tests/test_parse_page_description.py
@@ -22,3 +22,16 @@ def test_parse_page_uses_meta_description():
     """
     result = parse_page(html, "http://example.com")
     assert result["Book_Description"] == "meta description here"
+
+
+def test_parse_page_extracts_full_detail():
+    html = """
+    <html>
+      <body>
+        <h1>عنوانی</h1>
+        <div class='full description'>full detail text here</div>
+      </body>
+    </html>
+    """
+    result = parse_page(html, "http://example.com")
+    assert result["Book_Detail"] == "full detail text here"

--- a/tools/csv_to_podcast.py
+++ b/tools/csv_to_podcast.py
@@ -76,8 +76,8 @@ def build_item(row, pubdate):
     # fields that may be removed if the description grows too long.
     field_map = [
         ("Book_Title", "عنوان کتاب", False),
-        ("Book_Description", "توضیحات کتاب", False),
-        ("Book_Detail", "جزئیات/متن کامل معرفی", False),
+        # Use the full detail text instead of the shorter description.
+        ("Book_Detail", "توضیحات کتاب", False),
         ("Book_Summary", "خلاصه کتاب", False),
         ("Book_Language", "زبان کتاب", True),
         ("Book_Country", "کشور (منشأ یا مخاطب)", True),
@@ -156,14 +156,15 @@ def main():
     ap.add_argument("--out-dir", default="public/feeds")
     ap.add_argument("--run-name", default=os.getenv("RUN_NAME","latest"))
     ap.add_argument("--site", required=True)
-    ap.add_argument("--channel-title", default="کتاب‌های صوتی گلچین شده در ایران صدا")
+    ap.add_argument("--channel-title", default="گلچین کتاب های گویای ایران صدا")
     ap.add_argument("--channel-author", default="Mustafa")
     ap.add_argument("--channel-summary", default="جمع آوری بخشی از کتاب های صوتی موجود در سایت ایران صدا  در جهت استفاده در نرم افزار پادگیر")
     args = ap.parse_args()
 
     rows = read_rows(args.csv)
     pubdate = now_rfc822()
-    cover = rows and safe_get(rows[0], "Cover_Image_URL") or ""
+    # Static podcast logo as requested.
+    cover = "http://book.iranseda.ir/css/radio-book/book-black.svg"
 
     items = []
     for r in rows:


### PR DESCRIPTION
## Summary
- use the `Book_Detail` field for podcast item descriptions
- update channel title and use a static logo image for the feed
- adjust tests to reflect the description change and ensure full detail parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab158ab6f083259bb60abda93dfd44