### PR TITLE
Use Book_Detail for feed description and update channel info

### DIFF
--- a/tests/test_parse_page_description.py
+++ b/tests/test_parse_page_description.py
@@ -22,3 +22,16 @@ def test_parse_page_uses_meta_description():
     """
     result = parse_page(html, "http://example.com")
     assert result["Book_Description"] == "meta description here"
+
+
+def test_parse_page_extracts_full_detail():
+    html = """
+    <html>
+      <body>
+        <h1>عنوانی</h1>
+        <div class='full description'>full detail text here</div>
+      </body>
+    </html>
+    """
+    result = parse_page(html, "http://example.com")
+    assert result["Book_Detail"] == "full detail text here"


### PR DESCRIPTION
## Summary
- populate missing `Book_Detail` values by fetching and parsing the detail page
- cover new fetching logic with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab158ab6f083259bb60abda93dfd44